### PR TITLE
fix(ci): add new line between networks when combining endpoints

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -32,7 +32,7 @@ jobs:
           echo "mainnet:" > $TARGET
           cat endpoints/mainnet.yaml >> $TARGET
           # dump all endpoints into target except for mainnet
-          for body in endpoints/*.yaml; do filename=$(basename -- ${body%.*});  if [ "$filename" != "mainnet" ]; then echo "${filename}:" >> $TARGET; cat "$body" >> $TARGET; fi; done
+          for body in endpoints/*.yaml; do filename=$(basename -- ${body%.*});  if [ "$filename" != "mainnet" ]; then echo "\n${filename}:" >> $TARGET; cat "$body" >> $TARGET; fi; done
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:


### PR DESCRIPTION
Related: https://github.com/eth-clients/checkpoint-sync-endpoints/actions/runs/3135395123/jobs/5091015589

Combined `_data/endpoints.yaml` needs a new line between networks