### PR TITLE
Add beaconstate-holesky.chainsafe.io.

### DIFF
--- a/endpoints/holesky.yaml
+++ b/endpoints/holesky.yaml
@@ -1,0 +1,11 @@
+- endpoint: https://holesky.beaconstate.info
+  name: BeaconState.info
+  state: true
+  verification: true
+- endpoint: https://beaconstate-holesky.chainsafe.io
+  name: Lodestar (ChainSafe)
+  state: true
+  verification: true
+  contacts:
+    - name: "lodestar_eth"
+      link: https://twitter.com/lodestar_eth


### PR DESCRIPTION
Built on top of #29 to add Lodestar (ChainSafe) checkpointz to Holesky checkpoint directory.