### PR TITLE
Remove the EthStaker Goerli checkpoint sync endpoint

### DIFF
--- a/endpoints/goerli.yaml
+++ b/endpoints/goerli.yaml
@@ -32,13 +32,6 @@
   contacts:
     - name: "@Stakely_io"
       link: https://twitter.com/Stakely_io
-- endpoint: https://goerli.beaconstate.ethstaker.cc/
-  name: EthStaker
-  state: true
-  verification: true
-  contacts:
-    - name: "@remy_roy"
-      link: https://twitter.com/remy_roy
 - endpoint: https://prater.checkpoint.sigp.io
   name: Sigma Prime
   state: true


### PR DESCRIPTION
EthStaker is winding down all of its Goerli services with the deprecation of Goerli. We are removing our Goerli checkpoint sync endpoint in the coming days.