### PR TITLE
Typo corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Some common examples formatted in YAML
 
 ### Basic
 
-Adding a mainnet endpoint involes appending endpoint data to [`endpoints/mainnet.yaml`](./endpoints/mainnet.yaml);
+Adding a mainnet endpoint involves appending endpoint data to [`endpoints/mainnet.yaml`](./endpoints/mainnet.yaml);
 ```yaml
 - endpoint: https://checkpoint-sync.example.com
   name: example.com

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Endpoints can provide 3 main functions:
 
 -----
 <p align="center" style="display: inline-block"> 
-  <a target=”_blank” href="https://eth-clients.github.io/checkpoint-sync-endpoints">View the list here </a>
+  <a target="_blank" href="https://eth-clients.github.io/checkpoint-sync-endpoints">View the list here </a>
 </p>
 
 -----


### PR DESCRIPTION
### Added typo corrections to documentation for the following files

**CONTRIBUTING.md**

The word "involes" should be "involves".

Corrected.

**README.md**

The quotes around the target attribute should be standard, not typographic. Replaced `”` with regular quotes `"`.

Corrected.

### Goal

Correct grammatical errors and improve readability of the documentation.
