### PR TITLE
chore: bump all actions dependencies

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
       - name: Prepare endpoints
         run: |
           # setup Jekyll data dir
@@ -38,13 +38,13 @@ jobs:
         with:
           source: ./
           destination: ./_site
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: endpoints
           path: _data/endpoints.yaml
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
   deploy:
     environment:
       name: github-pages
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/vet.yaml
+++ b/.github/workflows/vet.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Lint
-        uses: nrkno/yaml-schema-validator-github-action@v5
+        uses: nrkno/yaml-schema-validator-github-action@v4
         with:
           schema: schema.yaml
           target: endpoints

--- a/.github/workflows/vet.yaml
+++ b/.github/workflows/vet.yaml
@@ -1,6 +1,6 @@
 name: Vet
 
-on:  
+on:
   pull_request:
     branches:
       - main
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Lint
-        uses: nrkno/yaml-schema-validator-github-action@v4
+        uses: nrkno/yaml-schema-validator-github-action@v5
         with:
           schema: schema.yaml
           target: endpoints


### PR DESCRIPTION
The `main` branch is currently broken due to outdated `actions/upload-artifact@v3`