### PR TITLE
remove deprecated sync.invis.tools endpoint

### DIFF
--- a/endpoints/mainnet.yaml
+++ b/endpoints/mainnet.yaml
@@ -9,16 +9,6 @@
   name: BeaconState.info
   state: true
   verification: true
-- endpoint: https://sync.invis.tools
-  name: invis.tools
-  state: true
-  verification: true
-  contacts:
-    - name: "@0xinvis"
-      link: https://twitter.com/0xinvis
-  notes:
-    - name: Uptime
-      link: https://status.invis.tools/
 - endpoint: https://beaconstate.ethstaker.cc
   name: EthStaker
   state: true


### PR DESCRIPTION
domain will from now on permanently redirect to `sync.beaconcha.in`, and there’s no need to advertise a redirect.