### PR TITLE
Remove beaconstate.info from endpoint lists

### DIFF
--- a/endpoints/holesky.yaml
+++ b/endpoints/holesky.yaml
@@ -1,7 +1,3 @@
-- endpoint: https://holesky.beaconstate.info
-  name: BeaconState.info
-  state: true
-  verification: true
 - endpoint: https://beaconstate-holesky.chainsafe.io
   name: Lodestar (ChainSafe)
   state: true

--- a/endpoints/hoodi.yaml
+++ b/endpoints/hoodi.yaml
@@ -1,7 +1,3 @@
-- endpoint: https://hoodi.beaconstate.info
-  name: BeaconState.info
-  state: true
-  verification: true
 - endpoint: https://hoodi.beaconstate.ethstaker.cc/
   name: EthStaker
   state: true

--- a/endpoints/mainnet.yaml
+++ b/endpoints/mainnet.yaml
@@ -5,10 +5,6 @@
   contacts:
     - name: "@beaconcha_in"
       link: https://twitter.com/beaconcha_in
-- endpoint: https://beaconstate.info
-  name: BeaconState.info
-  state: true
-  verification: true
 - endpoint: https://beaconstate.ethstaker.cc
   name: EthStaker
   state: true

--- a/endpoints/sepolia.yaml
+++ b/endpoints/sepolia.yaml
@@ -1,7 +1,3 @@
-- endpoint: https://sepolia.beaconstate.info
-  name: BeaconState.info
-  state: true
-  verification: true
 - endpoint: https://checkpoint-sync.sepolia.ethpandaops.io
   name: ethPandaOps
   state: true


### PR DESCRIPTION
Remove the beaconstate.info checkpoint sync endpoints from mainnet, hoodi, sepolia, and holesky.